### PR TITLE
Replace Material UI with Radix UI and CSS modules

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -59,7 +59,9 @@
       "Bash(BACKEND_URL=http://localhost:8080 bun run test swagger-ui-functionality.spec.ts)",
       "Bash(BACKEND_URL=http://localhost:8080 bun run test:e2e tests/swagger-ui-functionality.spec.ts)",
       "Bash(docker stop:*)",
-      "Bash(docker rm:*)"
+      "Bash(docker rm:*)",
+      "Bash(/Users/yukilab/.nvm/versions/node/v22.14.0/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg -n \"50\" --type md)",
+      "Bash(rm:*)"
     ],
     "deny": []
   }

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -4,8 +4,12 @@
     "": {
       "name": "pcafe2025-frontend",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.0.2",
         "@reduxjs/toolkit": "^2.0.1",
         "chart.js": "^4.4.0",
@@ -221,6 +225,8 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
 
+    "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.14", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ=="],
+
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
@@ -239,7 +245,11 @@
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
 
+    "@radix-ui/react-icons": ["@radix-ui/react-icons@1.3.2", "", { "peerDependencies": { "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc" } }, "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g=="],
+
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-label": ["@radix-ui/react-label@2.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
 
@@ -250,6 +260,8 @@
     "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.5", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.2", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA=="],
+
+    "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -291,7 +303,7 @@
 
     "@remix-run/router": ["@remix-run/router@1.23.0", "", {}, "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.9", "", {}, "sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.11", "", {}, "sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.42.0", "", { "os": "android", "cpu": "arm" }, "sha512-gldmAyS9hpj+H6LpRNlcjQWbuKUtb94lodB9uCz71Jm+7BxK1VIOo7y62tZZwxhA7j1ylv/yQz080L5WkS+LoQ=="],
 
@@ -495,7 +507,7 @@
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.14", "", {}, "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="],
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@18.3.23", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w=="],
 
@@ -525,9 +537,9 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.1", "", { "dependencies": { "@babel/core": "^7.26.10", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@rolldown/pluginutils": "1.0.0-beta.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.2", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.11", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-QNVT3/Lxx99nMQWJWF7K4N6apUEuT0KlZA3mx/mVaoGj3smm/8rc8ezz15J1pcbcjDK0V15rpHetVfya08r76Q=="],
 
-    "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -713,9 +725,9 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.165", "", {}, "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.166", "", {}, "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw=="],
 
-    "entities": ["entities@6.0.0", "", {}, "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="],
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
@@ -1377,9 +1389,13 @@
 
     "@mui/utils/react-is": ["react-is@19.1.0", "", {}, "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="],
 
+    "@types/estree-jsx/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "hast-util-to-jsx-runtime/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,12 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@reduxjs/toolkit": "^2.0.1",
     "chart.js": "^4.4.0",

--- a/frontend/src/admin/components/CustomAppBar.module.css
+++ b/frontend/src/admin/components/CustomAppBar.module.css
@@ -1,0 +1,50 @@
+.appBar {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  background-color: #1976d2;
+  color: white;
+  min-height: 64px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.userInfo {
+  display: flex;
+  align-items: center;
+  margin-right: 16px;
+}
+
+.userText {
+  margin: 0;
+  margin-right: 8px;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.homeButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.homeButton:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.homeIcon {
+  width: 20px;
+  height: 20px;
+}

--- a/frontend/src/admin/components/CustomAppBar.tsx
+++ b/frontend/src/admin/components/CustomAppBar.tsx
@@ -1,36 +1,30 @@
 import { AppBar, AppBarProps, useGetIdentity } from 'react-admin'
-import { Box, Button, Typography } from '@mui/material'
-import HomeIcon from '@mui/icons-material/Home'
+import { HomeIcon } from '@radix-ui/react-icons'
+import styles from './CustomAppBar.module.css'
 
 export const CustomAppBar = (props: AppBarProps) => {
   const { data: identity, isLoading } = useGetIdentity()
 
   return (
     <AppBar {...props}>
-      <Box flex="1" />
+      <div className={styles.spacer} />
 
       {/* User Info */}
       {!isLoading && identity && (
-        <Box display="flex" alignItems="center" marginRight={2}>
-          <Typography variant="body2" color="inherit" sx={{ marginRight: 1 }}>
+        <div className={styles.userInfo}>
+          <p className={styles.userText}>
             Welcome, {identity.fullName || identity.username || 'Admin'}
-          </Typography>
-        </Box>
+          </p>
+        </div>
       )}
 
-      <Button
-        color="inherit"
+      <a
         href="/"
-        startIcon={<HomeIcon />}
-        sx={{
-          marginRight: 2,
-          '&:hover': {
-            backgroundColor: 'rgba(255, 255, 255, 0.1)'
-          }
-        }}
+        className={styles.homeButton}
       >
+        <HomeIcon className={styles.homeIcon} />
         Back to Main Site
-      </Button>
+      </a>
     </AppBar>
   )
 }

--- a/frontend/src/admin/resources/events.module.css
+++ b/frontend/src/admin/resources/events.module.css
@@ -1,0 +1,118 @@
+.container {
+  padding: 16px;
+}
+
+.card {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.cardContent {
+  padding: 24px;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: #1f2937;
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: 8px 16px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.button:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.button.contained {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+
+.button.contained:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.inputContainer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.fileInput {
+  margin-top: 8px;
+}
+
+.helpText {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 8px;
+  margin-bottom: 0;
+}
+
+.alert {
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.alert.info {
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+}
+
+.alert.error {
+  background-color: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
+}
+
+.codeBlock {
+  background-color: #f5f5f5;
+  padding: 16px;
+  border-radius: 4px;
+  overflow: auto;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  margin: 0;
+}

--- a/frontend/src/admin/resources/events.tsx
+++ b/frontend/src/admin/resources/events.tsx
@@ -19,7 +19,7 @@ import {
   useNotify,
 } from 'react-admin'
 import { useState } from 'react'
-import { Card, CardContent, Typography, Box, TextField as MuiTextField, Alert, Button as MuiButton } from '@mui/material'
+import styles from './events.module.css'
 
 export const EventList = () => (
   <List>
@@ -176,63 +176,61 @@ export const EventCreate = () => {
 
   return (
     <Create>
-      <Box>
+      <div className={styles.container}>
         {/* Input Method Selection */}
-        <Card style={{ marginBottom: '1rem' }}>
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
+        <div className={styles.card}>
+          <div className={styles.cardContent}>
+            <h2 className={styles.title}>
               Event Creation Method
-            </Typography>
-            <Box display="flex" gap={2} flexWrap="wrap">
-              <MuiButton
-                variant={metadataMode === 'manual' ? 'contained' : 'outlined'}
+            </h2>
+            <div className={styles.buttonGroup}>
+              <button
+                className={`${styles.button} ${metadataMode === 'manual' ? styles.contained : ''}`}
                 onClick={() => setMetadataMode('manual')}
               >
                 Manual Entry
-              </MuiButton>
-              <MuiButton
-                variant={metadataMode === 'url' ? 'contained' : 'outlined'}
+              </button>
+              <button
+                className={`${styles.button} ${metadataMode === 'url' ? styles.contained : ''}`}
                 onClick={() => setMetadataMode('url')}
               >
                 Extract from URL
-              </MuiButton>
-              <MuiButton
-                variant={metadataMode === 'image' ? 'contained' : 'outlined'}
+              </button>
+              <button
+                className={`${styles.button} ${metadataMode === 'image' ? styles.contained : ''}`}
                 onClick={() => setMetadataMode('image')}
               >
                 Process Image (OCR)
-              </MuiButton>
-              <MuiButton
-                variant={metadataMode === 'pdf' ? 'contained' : 'outlined'}
+              </button>
+              <button
+                className={`${styles.button} ${metadataMode === 'pdf' ? styles.contained : ''}`}
                 onClick={() => setMetadataMode('pdf')}
               >
                 Process PDF
-              </MuiButton>
-            </Box>
-          </CardContent>
-        </Card>
+              </button>
+            </div>
+          </div>
+        </div>
 
         {/* URL Extraction */}
         {metadataMode === 'url' && (
-          <Card style={{ marginBottom: '1rem' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
+          <div className={styles.card}>
+            <div className={styles.cardContent}>
+              <h2 className={styles.title}>
                 Extract Metadata from URL
-              </Typography>
-              <Box display="flex" gap={2} alignItems="center">
-                <MuiTextField
-                  label="Event URL"
+              </h2>
+              <div className={styles.inputContainer}>
+                <input
+                  className={styles.input}
                   placeholder="https://example.com/event"
-                  variant="outlined"
-                  style={{ flex: 1 }}
                   onKeyPress={(e) => {
                     if (e.key === 'Enter') {
                       handleUrlExtraction((e.target as HTMLInputElement).value)
                     }
                   }}
                 />
-                <MuiButton
-                  variant="contained"
+                <button
+                  className={`${styles.button} ${styles.contained}`}
                   onClick={(e) => {
                     const input = e.currentTarget.parentElement?.querySelector('input') as HTMLInputElement
                     handleUrlExtraction(input.value)
@@ -240,77 +238,79 @@ export const EventCreate = () => {
                   disabled={loading}
                 >
                   Extract
-                </MuiButton>
-              </Box>
-            </CardContent>
-          </Card>
+                </button>
+              </div>
+            </div>
+          </div>
         )}
 
         {/* Image Upload */}
         {metadataMode === 'image' && (
-          <Card style={{ marginBottom: '1rem' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
+          <div className={styles.card}>
+            <div className={styles.cardContent}>
+              <h2 className={styles.title}>
                 Upload Image for OCR Processing
-              </Typography>
+              </h2>
               <input
                 type="file"
                 accept="image/*"
                 onChange={handleImageUpload}
                 disabled={loading}
+                className={styles.fileInput}
               />
-              <Typography variant="body2" color="textSecondary" style={{ marginTop: '0.5rem' }}>
+              <p className={styles.helpText}>
                 Supported formats: JPEG, PNG, GIF, BMP, WebP, TIFF
-              </Typography>
-            </CardContent>
-          </Card>
+              </p>
+            </div>
+          </div>
         )}
 
         {/* PDF Upload */}
         {metadataMode === 'pdf' && (
-          <Card style={{ marginBottom: '1rem' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
+          <div className={styles.card}>
+            <div className={styles.cardContent}>
+              <h2 className={styles.title}>
                 Upload PDF for Text Extraction
-              </Typography>
+              </h2>
               <input
                 type="file"
                 accept=".pdf"
                 onChange={handlePdfUpload}
                 disabled={loading}
+                className={styles.fileInput}
               />
-              <Typography variant="body2" color="textSecondary" style={{ marginTop: '0.5rem' }}>
+              <p className={styles.helpText}>
                 PDF files will be processed to extract event information
-              </Typography>
-            </CardContent>
-          </Card>
+              </p>
+            </div>
+          </div>
         )}
 
         {/* Loading and Error States */}
         {loading && (
-          <Alert severity="info" style={{ marginBottom: '1rem' }}>
+          <div className={`${styles.alert} ${styles.info}`}>
             Processing... Please wait.
-          </Alert>
+          </div>
         )}
 
         {error && (
-          <Alert severity="error" style={{ marginBottom: '1rem' }}>
+          <div className={`${styles.alert} ${styles.error}`}>
             {error}
-          </Alert>
+          </div>
         )}
 
         {/* Extracted Data Preview */}
         {extractedData && (
-          <Card style={{ marginBottom: '1rem' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
+          <div className={styles.card}>
+            <div className={styles.cardContent}>
+              <h2 className={styles.title}>
                 Extracted Data Preview
-              </Typography>
-              <pre style={{ backgroundColor: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+              </h2>
+              <pre className={styles.codeBlock}>
                 {JSON.stringify(extractedData, null, 2)}
               </pre>
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         )}
 
         {/* Event Form */}
@@ -329,7 +329,7 @@ export const EventCreate = () => {
           <BooleanInput source="is_published" defaultValue={false} />
           <BooleanInput source="is_featured" defaultValue={false} />
         </SimpleForm>
-      </Box>
+      </div>
     </Create>
   )
 }

--- a/frontend/src/admin/resources/iot.module.css
+++ b/frontend/src/admin/resources/iot.module.css
@@ -1,0 +1,84 @@
+.dashboard {
+  padding: 20px;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0 0 24px 0;
+  color: #1f2937;
+}
+
+.gridContainer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.cardContent {
+  padding: 24px;
+}
+
+.cardTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: #1f2937;
+}
+
+.deviceItem {
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.deviceItem:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.deviceName {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: #1f2937;
+}
+
+.deviceInfo {
+  font-size: 0.875rem;
+  margin: 2px 0;
+  color: #6b7280;
+}
+
+.statItem {
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.statItem:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.statName {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: #1f2937;
+}
+
+.statValues {
+  font-size: 0.875rem;
+  margin: 0;
+  color: #6b7280;
+}

--- a/frontend/src/admin/resources/iot.tsx
+++ b/frontend/src/admin/resources/iot.tsx
@@ -14,7 +14,7 @@ import {
   Loading,
   Error
 } from 'react-admin'
-import { Card, CardContent, Typography, Grid } from '@mui/material'
+import styles from './iot.module.css'
 
 // Filter component for IoT data
 const IoTDataFilter = (props: Record<string, unknown>) => (
@@ -94,61 +94,57 @@ export const IoTStatsDashboard = () => {
   if (error) return <Error error={error} resetErrorBoundary={() => {}} />
 
   return (
-    <div style={{ padding: '20px' }}>
-      <Typography variant="h4" gutterBottom>
+    <div className={styles.dashboard}>
+      <h1 className={styles.title}>
         IoT Data Overview
-      </Typography>
+      </h1>
       
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Active Devices
-              </Typography>
-              {devices?.map((device: { device_id: string; device_name: string; device_type: string; location: string; last_seen: string; sensor_types?: string[] }) => (
-                <div key={device.device_id} style={{ marginBottom: '10px' }}>
-                  <Typography variant="subtitle2">
-                    {device.device_name} ({device.device_id})
-                  </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    Location: {device.location} | Type: {device.device_type}
-                  </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    Last seen: {new Date(device.last_seen).toLocaleString()}
-                  </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    Sensors: {device.sensor_types?.join(', ')}
-                  </Typography>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </Grid>
+      <div className={styles.gridContainer}>
+        <div className={styles.card}>
+          <div className={styles.cardContent}>
+            <h2 className={styles.cardTitle}>
+              Active Devices
+            </h2>
+            {devices?.map((device: { device_id: string; device_name: string; device_type: string; location: string; last_seen: string; sensor_types?: string[] }) => (
+              <div key={device.device_id} className={styles.deviceItem}>
+                <h3 className={styles.deviceName}>
+                  {device.device_name} ({device.device_id})
+                </h3>
+                <p className={styles.deviceInfo}>
+                  Location: {device.location} | Type: {device.device_type}
+                </p>
+                <p className={styles.deviceInfo}>
+                  Last seen: {new Date(device.last_seen).toLocaleString()}
+                </p>
+                <p className={styles.deviceInfo}>
+                  Sensors: {device.sensor_types?.join(', ')}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
         
-        <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Data Statistics
-              </Typography>
-              {stats?.map((stat: { device_id: string; sensor_type: string; count: number; min_value?: number; max_value?: number; avg_value?: number }) => (
-                <div key={`${stat.device_id}-${stat.sensor_type}`} style={{ marginBottom: '10px' }}>
-                  <Typography variant="subtitle2">
-                    {stat.device_id} - {stat.sensor_type}
-                  </Typography>
-                  <Typography variant="body2">
-                    Records: {stat.count} | 
-                    Min: {stat.min_value?.toFixed(2)} | 
-                    Max: {stat.max_value?.toFixed(2)} | 
-                    Avg: {stat.avg_value?.toFixed(2)}
-                  </Typography>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </Grid>
-      </Grid>
+        <div className={styles.card}>
+          <div className={styles.cardContent}>
+            <h2 className={styles.cardTitle}>
+              Data Statistics
+            </h2>
+            {stats?.map((stat: { device_id: string; sensor_type: string; count: number; min_value?: number; max_value?: number; avg_value?: number }) => (
+              <div key={`${stat.device_id}-${stat.sensor_type}`} className={styles.statItem}>
+                <h3 className={styles.statName}>
+                  {stat.device_id} - {stat.sensor_type}
+                </h3>
+                <p className={styles.statValues}>
+                  Records: {stat.count} | 
+                  Min: {stat.min_value?.toFixed(2)} | 
+                  Max: {stat.max_value?.toFixed(2)} | 
+                  Avg: {stat.avg_value?.toFixed(2)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
close #50

## Summary

- Replace Material UI components with Radix UI equivalents and CSS modules in admin components
- Maintain React Admin functionality while removing direct Material UI dependencies from custom components

## Changes Made

### Admin Components Refactored

1. **CustomAppBar** (`src/admin/components/CustomAppBar.tsx`)
   - Replaced `@mui/material` Box, Button, Typography with semantic HTML
   - Replaced `@mui/icons-material/Home` with `@radix-ui/react-icons/HomeIcon`
   - Created `CustomAppBar.module.css` for styling

2. **IoT Resource** (`src/admin/resources/iot.tsx`)
   - Replaced Material UI Card, CardContent, Typography, Grid components
   - Created `iot.module.css` with CSS Grid layout
   - Maintained IoT dashboard functionality

3. **Events Resource** (`src/admin/resources/events.tsx`)
   - Replaced extensive Material UI usage (Card, CardContent, Typography, Box, TextField, Button, Alert)
   - Created `events.module.css` with comprehensive styling
   - Preserved all event creation functionality including metadata extraction, OCR, and PDF processing

### Technical Improvements

- **CSS Modules**: All presentation logic moved to dedicated CSS module files
- **Radix UI Integration**: Added `@radix-ui/react-icons`, `@radix-ui/react-alert-dialog`, etc.
- **Performance**: Removed direct Material UI bundle dependencies from custom components
- **Maintainability**: Clean separation of concerns between logic and presentation
- **Type Safety**: All changes pass TypeScript checking and ESLint validation

## Test Plan

- [x] TypeScript compilation (`bun run typecheck`)
- [x] ESLint validation (`bun run lint`)
- [x] React Admin functionality preserved
- [x] All custom components use CSS modules instead of Material UI
- [x] Radix UI icons work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)