### PR TITLE
Fix frontend port configuration and API connectivity

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -61,7 +61,8 @@
       "Bash(docker stop:*)",
       "Bash(docker rm:*)",
       "Bash(/Users/yukilab/.nvm/versions/node/v22.14.0/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg -n \"50\" --type md)",
-      "Bash(rm:*)"
+      "Bash(rm:*)",
+      "Bash(PGPASSWORD=password psql:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ PCafe 2025 - A fresh project starting from scratch. The project name suggests it
 - UI：Radix UI
 - CSS: CSS Modules
 - 管理画面：React Admin（カスタムフォームあり）
-- local開発 port 3000q
+- local開発 port 4000
 
 #### バックエンド（API）
 
@@ -195,7 +195,7 @@ make docker-logs    # View logs
 **IoT Sample Data Population:**
 ```bash
 # Populate 60 days of sample IoT data via admin UI
-# 1. Navigate to http://localhost:3000/graphs
+# 1. Navigate to http://localhost:4000/graphs
 # 2. Login as admin
 # 3. Click "Populate Sample Data" button
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     environment:
       VITE_API_BASE_URL: http://localhost:8080
     ports:
-      - "3000:3000"
+      - "4000:4000"
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 # Development stage
 FROM base AS development
-EXPOSE 3000
+EXPOSE 4000
 CMD ["bun", "run", "dev", "--host", "0.0.0.0"]
 
 # Production build stage

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:4000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string | number | boolean>
@@ -12,6 +12,16 @@ class ApiClient {
   }
 
   private buildURL(endpoint: string, params?: Record<string, string | number | boolean>): string {
+    // Handle relative URLs when baseURL is empty (using Vite proxy)
+    if (!this.baseURL) {
+      const queryString = params ? 
+        '?' + Object.entries(params)
+          .filter(([_, value]) => value !== undefined && value !== null && value !== '')
+          .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+          .join('&') : ''
+      return `${endpoint}${queryString}`
+    }
+    
     const url = new URL(`${this.baseURL}${endpoint}`)
     
     if (params) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,7 +16,7 @@ class ApiClient {
     if (!this.baseURL) {
       const queryString = params ? 
         '?' + Object.entries(params)
-          .filter(([_, value]) => value !== undefined && value !== null && value !== '')
+          .filter(([, value]) => value !== undefined && value !== null && value !== '')
           .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
           .join('&') : ''
       return `${endpoint}${queryString}`

--- a/frontend/tests/all-pages-test.spec.ts
+++ b/frontend/tests/all-pages-test.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('All Pages Test', () => {
+  test.beforeEach(async ({ page }) => {
+    // Set a longer timeout for navigation
+    page.setDefaultTimeout(30000);
+  });
+
+  test('Homepage loads successfully', async ({ page }) => {
+    await page.goto('http://localhost:4000/');
+    await expect(page).toHaveTitle(/PCafe 2025/);
+    await expect(page.locator('h1')).toContainText(/Welcome to PCafe 2025/);
+  });
+
+  test('Events page loads and displays events', async ({ page }) => {
+    await page.goto('http://localhost:4000/events');
+    await expect(page.locator('h1')).toContainText(/Events/);
+    
+    // Wait for events to load
+    await page.waitForSelector('.event-item, [class*="event"]', { timeout: 10000 }).catch(() => {
+      // If no events, check for empty state
+      return page.waitForSelector('text=/No events/', { timeout: 5000 });
+    });
+  });
+
+  test('Blog page loads and displays posts', async ({ page }) => {
+    await page.goto('http://localhost:4000/blog');
+    await expect(page.locator('h1')).toContainText(/Blog/);
+    
+    // Wait for blog posts to load
+    await page.waitForSelector('.blog-post, [class*="blog"]', { timeout: 10000 }).catch(() => {
+      // If no posts, check for empty state
+      return page.waitForSelector('text=/No posts/', { timeout: 5000 });
+    });
+  });
+
+  test('Graphs page loads successfully', async ({ page }) => {
+    await page.goto('http://localhost:4000/graphs');
+    await expect(page.locator('h1')).toContainText(/IoT Data/);
+  });
+
+  test('Contact page loads successfully', async ({ page }) => {
+    await page.goto('http://localhost:4000/contact');
+    await expect(page.locator('h1')).toContainText(/Contact/);
+    
+    // Check for form elements
+    await expect(page.locator('input[name="name"], input[placeholder*="name" i]')).toBeVisible();
+    await expect(page.locator('input[name="email"], input[placeholder*="email" i]')).toBeVisible();
+    await expect(page.locator('textarea')).toBeVisible();
+  });
+
+  test('Admin page redirects to login', async ({ page }) => {
+    await page.goto('http://localhost:4000/admin');
+    
+    // Should either show login form or redirect to login
+    await expect(page.locator('input[type="password"], input[name="password"]')).toBeVisible();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
     plugins: [react()],
     server: {
-        port: 3000,
+        port: 4000,
         proxy: {
             '/api': {
                 target: 'http://localhost:8080',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    port: 4000,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',


### PR DESCRIPTION
close #45

## Summary
- Changed frontend development port from 3000 to 4000 for consistency
- Fixed API URL construction to properly handle Vite proxy configuration
- Updated all documentation, Docker, and test configurations for new port

## Changes Made
- Updated `vite.config.ts` and `vite.config.js` to use port 4000
- Fixed API client to handle empty baseURL for Vite proxy support
- Updated `docker-compose.yml`, `Dockerfile`, and `playwright.config.ts`
- Updated documentation in `CLAUDE.md` to reflect new port
- Added comprehensive test suite for all main application pages

## Test Plan
- [x] Frontend server starts on port 4000
- [x] All main pages load successfully (/, /events, /blog, /graphs, /contact)
- [x] Backend API connectivity verified through Vite proxy
- [x] No console errors on page loads
- [x] Test suite added to verify page functionality

🤖 Generated with [Claude Code](https://claude.ai/code)